### PR TITLE
Fix visulization resources id

### DIFF
--- a/app/components/Visualization.js
+++ b/app/components/Visualization.js
@@ -22,7 +22,7 @@ export default class Visualization extends Component {
     const dependencies = [];
     for (let i = 0; i < this.resources.length; i += 1) {
       const resource = this.resources[i];
-      const id = `${resource.type}${resource.displayName}`;
+      const id = `${resource.type}/${resource.displayName}`;
 
       const dependsOn = resource.dependsOn || [];
       for (let y = 0; y < dependsOn.length; y += 1) {


### PR DESCRIPTION
I noticed that graph isn't working.
The problem is with resource id, but I am not sure if my fix is correct.
After added separator `/` graph starts working, but maybe the problem is somewhere inside `TemplateParser`.